### PR TITLE
Fix application spec URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
 
 ## Getting started
 
-- Read the [Application Specification](https://github.com/tastejs/todomvc/blob/gh-pages/app-spec.md) before touching the template.
+- Read the [Application Specification](https://github.com/tastejs/todomvc/blob/master/app-spec.md) before touching the template.
 
 - Delete this file and rename `app-readme.md` to `readme.md` and fill it out.
 


### PR DESCRIPTION
The application spec URL was incorrect. It has been updated to point to the correct branch on the main repository.